### PR TITLE
Prevent Test Files In Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buoy-kit",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Fetch buoy and tide information from government NDBC data using JavaScript.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Derek Dowling",
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "prepublishOnly": "yarn prettier && yarn test && yarn clean && yarn build",
     "prettier": "prettier -l \"src/**/*.{ts,json,js}\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buoy-kit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Fetch buoy and tide information from government NDBC data using JavaScript.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/**/test.ts"]
 }


### PR DESCRIPTION
Fix the build command to use the `tsconfig.build.json` file so we aren't bundling test files into our production package 🤦‍♂️ 